### PR TITLE
Fix typo in species.json: Corrected the spelling of "fezandipity" to …

### DIFF
--- a/data/species.json
+++ b/data/species.json
@@ -1014,7 +1014,7 @@
   "sinistcha": 1013,
   "okidogi": 1014,
   "munkidori": 1015,
-  "fezandipity": 1016,
+  "fezandipiti": 1016,
   "ogerpon": 1017,
   "archaludon": 1018,
   "hydrapple": 1019,


### PR DESCRIPTION
…"fezandipiti" for consistency in species naming.