### PR TITLE
Add shop page and navigation links

### DIFF
--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Shop | Pokemon Palette',
+  description: 'Download premium color palette packs and design assets.',
+};
+
+const products = [
+  {
+    title: 'Starter Palette Pack',
+    description: '10 curated palette bundles inspired by Kanto Pokémon.',
+    price: '€5',
+    link: 'https://gumroad.com',
+  },
+  {
+    title: 'Advanced Palette Pack',
+    description: '30 advanced palettes and gradient sets.',
+    price: '€15',
+    link: 'https://gumroad.com',
+  },
+];
+
+export default function ShopPage() {
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-8">
+      <h1 className="text-3xl font-bold">Shop</h1>
+      <p className="text-muted-foreground">
+        Explore premium palette packs crafted for designers. Purchases open in a new tab.
+      </p>
+      <div className="space-y-6">
+        {products.map(product => (
+          <div key={product.title} className="border rounded-lg p-4 space-y-2">
+            <h2 className="text-xl font-semibold">{product.title}</h2>
+            <p className="text-sm text-muted-foreground">{product.description}</p>
+            <a
+              href={product.link}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium rounded-md transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
+            >
+              Buy for {product.price}
+            </a>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Pokemon Palette is not affiliated with "The Pokémon Company" or Nintendo.
+      </p>
+    </div>
+  );
+}

--- a/components/landing/navbar.tsx
+++ b/components/landing/navbar.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { SignInButton, UserButton, SignedIn, SignedOut, useUser } from '@clerk/nextjs';
-import { Bookmark, Check, Menu, Palette, Sparkles, User, LogIn } from 'lucide-react';
+import { Bookmark, Check, Menu, Palette, Sparkles, User, LogIn, ShoppingCart } from 'lucide-react';
 import Link from 'next/link';
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
@@ -260,6 +260,19 @@ export function Navbar({ colors, pokemonName, pokemonNumber, getContrastColor }:
                       )}
                     </Button>
 
+                    <Link
+                      href="/shop"
+                      className="mt-1 inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition-all hover:opacity-90 active:scale-95"
+                      style={{
+                        backgroundColor: colors[2],
+                        color:
+                          getContrastColor(colors[2]).text === 'text-white' ? 'white' : 'black',
+                      }}
+                    >
+                      <ShoppingCart className="w-4 h-4 mr-2" />
+                      <span>Shop</span>
+                    </Link>
+
                     <a
                       href="https://www.buymeacoffee.com/yassenshopov"
                       target="_blank"
@@ -310,6 +323,19 @@ export function Navbar({ colors, pokemonName, pokemonNumber, getContrastColor }:
                         Sign in
                       </Button>
                     </SignInButton>
+
+                    <Link
+                      href="/shop"
+                      className="mt-1 inline-flex items-center px-3 py-2 text-sm font-medium rounded-md transition-all hover:opacity-90 active:scale-95"
+                      style={{
+                        backgroundColor: colors[2],
+                        color:
+                          getContrastColor(colors[2]).text === 'text-white' ? 'white' : 'black',
+                      }}
+                    >
+                      <ShoppingCart className="w-4 h-4 mr-2" />
+                      <span>Shop</span>
+                    </Link>
 
                     <a
                       href="https://www.buymeacoffee.com/yassenshopov"
@@ -433,6 +459,18 @@ export function Navbar({ colors, pokemonName, pokemonNumber, getContrastColor }:
 
             {/* Separator - Desktop only */}
             <div className="h-4 w-px bg-border/50 mx-1" />
+
+            <Link
+              href="/shop"
+              className="inline-flex items-center px-3 h-8 text-sm font-medium rounded-lg transition-all hover:opacity-90 active:scale-95"
+              style={{
+                backgroundColor: colors[2],
+                color: getContrastColor(colors[2]).text === 'text-white' ? 'white' : 'black',
+              }}
+            >
+              <ShoppingCart className="w-4 h-4 mr-2" />
+              <span>Shop</span>
+            </Link>
 
             {/* Support Button - Desktop only */}
             <a

--- a/components/ui/Footer.tsx
+++ b/components/ui/Footer.tsx
@@ -83,6 +83,13 @@ export function Footer() {
               </a>
               <span className="text-muted-foreground">•</span>
               <a
+                href="/shop"
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Shop
+              </a>
+              <span className="text-muted-foreground">•</span>
+              <a
                 href="https://buymeacoffee.com/yassenshopov"
                 target="_blank"
                 rel="noreferrer"


### PR DESCRIPTION
## Summary
- create new `/shop` route displaying palette packs for purchase
- add Shop link to navbar for mobile and desktop
- link to Shop page from footer

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d166a4c8330b15df2fe5b83e7de